### PR TITLE
Add extraErrors prop for async validation (#1444)

### DIFF
--- a/docs/advanced-customization.md
+++ b/docs/advanced-customization.md
@@ -247,6 +247,50 @@ The following props are passed to `ErrorList`
 - `uiSchema`: The uiSchema that was passed to `Form`.
 - `formContext`: The `formContext` object that you passed to Form.
 
+
+### Async Errors
+
+Handling async errors is an important part of many applications. Support for this is added in the form of the `errorSchema` prop.
+
+For example, a request could be made to some backend when the user submits the form. If that request fails, the errors returned by the backend should be formatted like in the following example.
+
+```jsx
+const schema = {
+  type: "object",
+  properties: {
+    foo: {
+      type: "string",
+    },
+    candy: {
+      type: "object",
+      properties: {
+        bar: {
+          type: "string",
+        }
+      }
+    },
+  },
+}
+
+const extraErrors = {
+  foo: {
+    __errors: ["some error that got added as a prop"],
+  },
+  candy: {
+    bar: {
+    __errors: ["some error that got added as a prop"],
+    }
+  }
+}
+
+render((
+  <Form schema={schema}
+        extraErrors={extraErrors} />,
+), document.getElementById("app"));
+```
+
+An important note is that these errors are 'display only' and will not block the user from submitting the form again.
+
 ### Id prefix
 
 To avoid collisions with existing ids in the DOM, it is possible to change the prefix used for ids (the default is `root`).

--- a/playground/app.js
+++ b/playground/app.js
@@ -348,7 +348,7 @@ class App extends Component {
 
   load = data => {
     // Reset the ArrayFieldTemplate whenever you load new data
-    const { ArrayFieldTemplate, ObjectFieldTemplate } = data;
+    const { ArrayFieldTemplate, ObjectFieldTemplate, extraErrors } = data;
     // uiSchema is missing on some examples. Provide a default to
     // clear the field in all cases.
     const { uiSchema = {} } = data;
@@ -360,6 +360,7 @@ class App extends Component {
         ArrayFieldTemplate,
         ObjectFieldTemplate,
         uiSchema,
+        extraErrors,
       })
     );
   };
@@ -369,6 +370,9 @@ class App extends Component {
   onUISchemaEdited = uiSchema => this.setState({ uiSchema, shareURL: null });
 
   onFormDataEdited = formData => this.setState({ formData, shareURL: null });
+
+  onExtraErrorsEdited = extraErrors =>
+    this.setState({ extraErrors, shareURL: null });
 
   onThemeSelected = (theme, { stylesheet, editor }) => {
     this.setState({ theme, editor: editor ? editor : "default" });
@@ -384,13 +388,25 @@ class App extends Component {
     this.setState({ formData, shareURL: null });
 
   onShare = () => {
-    const { formData, schema, uiSchema, liveSettings } = this.state;
+    const {
+      formData,
+      schema,
+      uiSchema,
+      liveSettings,
+      errorSchema,
+    } = this.state;
     const {
       location: { origin, pathname },
     } = document;
     try {
       const hash = btoa(
-        JSON.stringify({ formData, schema, uiSchema, liveSettings })
+        JSON.stringify({
+          formData,
+          schema,
+          uiSchema,
+          liveSettings,
+          errorSchema,
+        })
       );
       this.setState({ shareURL: `${origin}${pathname}#${hash}` });
     } catch (err) {
@@ -403,6 +419,7 @@ class App extends Component {
       schema,
       uiSchema,
       formData,
+      extraErrors,
       liveSettings,
       validate,
       theme,
@@ -458,6 +475,18 @@ class App extends Component {
               />
             </div>
           </div>
+          {extraErrors && (
+            <div className="row">
+              <div className="col">
+                <Editor
+                  title="extraErrors"
+                  theme={editor}
+                  code={toJson(extraErrors || {})}
+                  onChange={this.onExtraErrorsEdited}
+                />
+              </div>
+            </div>
+          )}
         </div>
         <div className="col-sm-5">
           {this.state.form && (
@@ -471,6 +500,7 @@ class App extends Component {
               schema={schema}
               uiSchema={uiSchema}
               formData={formData}
+              extraErrors={extraErrors}
               onChange={this.onFormDataChange}
               onSubmit={({ formData }, e) => {
                 console.log("submitted formData", formData);

--- a/playground/samples/errorSchema.js
+++ b/playground/samples/errorSchema.js
@@ -1,0 +1,74 @@
+module.exports = {
+  schema: {
+    title: "A registration form",
+    description: "A simple form example.",
+    type: "object",
+    required: ["firstName", "lastName"],
+    properties: {
+      firstName: {
+        type: "string",
+        title: "First name",
+        default: "Chuck",
+      },
+      lastName: {
+        type: "string",
+        title: "Last name",
+      },
+      age: {
+        type: "integer",
+        title: "Age",
+      },
+      bio: {
+        type: "string",
+        title: "Bio",
+      },
+      password: {
+        type: "string",
+        title: "Password",
+        minLength: 3,
+      },
+      telephone: {
+        type: "string",
+        title: "Telephone",
+        minLength: 10,
+      },
+    },
+  },
+  uiSchema: {
+    firstName: {
+      "ui:autofocus": true,
+      "ui:emptyValue": "",
+    },
+    age: {
+      "ui:widget": "updown",
+      "ui:title": "Age of person",
+      "ui:description": "(earthian year)",
+    },
+    bio: {
+      "ui:widget": "textarea",
+    },
+    password: {
+      "ui:widget": "password",
+      "ui:help": "Hint: Make it strong!",
+    },
+    date: {
+      "ui:widget": "alt-datetime",
+    },
+    telephone: {
+      "ui:options": {
+        inputType: "tel",
+      },
+    },
+  },
+  formData: {
+    lastName: "Norris",
+    age: 75,
+    bio: "Roundhouse kicking asses since 1940",
+    password: "noneed",
+  },
+  extraErrors: {
+    firstName: {
+      __errors: ["some error that got added as a prop"],
+    },
+  },
+};

--- a/playground/samples/index.js
+++ b/playground/samples/index.js
@@ -22,6 +22,7 @@ import schemaDependencies from "./schemaDependencies";
 import additionalProperties from "./additionalProperties";
 import nullable from "./nullable";
 import nullField from "./null";
+import errorSchema from "./errorSchema";
 
 export const samples = {
   Simple: simple,
@@ -48,4 +49,5 @@ export const samples = {
   "One Of": oneOf,
   "Null fields": nullField,
   Nullable: nullable,
+  ErrorSchema: errorSchema,
 };

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -17,6 +17,7 @@ import {
   isObject,
 } from "../utils";
 import validateFormData, { toErrorList } from "../validate";
+import { mergeObjects } from "../utils";
 
 export default class Form extends Component {
   static defaultProps = {
@@ -66,12 +67,16 @@ export default class Form extends Component {
     const retrievedSchema = retrieveSchema(schema, definitions, formData);
     const customFormats = props.customFormats;
     const additionalMetaSchemas = props.additionalMetaSchemas;
-    const { errors, errorSchema } = mustValidate
+    let { errors, errorSchema } = mustValidate
       ? this.validate(formData, schema, additionalMetaSchemas, customFormats)
       : {
           errors: state.errors || [],
           errorSchema: state.errorSchema || {},
         };
+    if (props.extraErrors) {
+      errorSchema = mergeObjects(errorSchema, props.extraErrors);
+      errors = toErrorList(errorSchema);
+    }
     const idSchema = toIdSchema(
       retrievedSchema,
       uiSchema["ui:rootFieldId"],
@@ -201,13 +206,20 @@ export default class Form extends Component {
     }
 
     if (mustValidate) {
-      const { errors, errorSchema } = this.validate(newFormData);
+      let { errors, errorSchema } = this.validate(newFormData);
+      if (this.props.extraErrors) {
+        errorSchema = mergeObjects(errorSchema, this.props.extraErrors);
+        errors = toErrorList(errorSchema);
+      }
       state = { formData: newFormData, errors, errorSchema };
     } else if (!this.props.noValidate && newErrorSchema) {
+      const errorSchema = this.props.extraErrors
+        ? mergeObjects(newErrorSchema, this.props.extraErrors)
+        : newErrorSchema;
       state = {
         formData: newFormData,
-        errorSchema: newErrorSchema,
-        errors: toErrorList(newErrorSchema),
+        errorSchema: errorSchema,
+        errors: toErrorList(errorSchema),
       };
     }
     setState(this, state, () => {
@@ -257,8 +269,12 @@ export default class Form extends Component {
     }
 
     if (!this.props.noValidate) {
-      const { errors, errorSchema } = this.validate(newFormData);
+      let { errors, errorSchema } = this.validate(newFormData);
       if (Object.keys(errors).length > 0) {
+        if (this.props.extraErrors) {
+          errorSchema = mergeObjects(errorSchema, this.props.extraErrors);
+          errors = toErrorList(errorSchema);
+        }
         setState(this, { errors, errorSchema }, () => {
           if (this.props.onError) {
             this.props.onError(errors);
@@ -270,8 +286,18 @@ export default class Form extends Component {
       }
     }
 
+    let errorSchema;
+    let errors;
+    if (this.props.extraErrors) {
+      errorSchema = this.props.extraErrors;
+      errors = toErrorList(errorSchema);
+    } else {
+      errorSchema = {};
+      errors = [];
+    }
+
     this.setState(
-      { formData: newFormData, errors: [], errorSchema: {} },
+      { formData: newFormData, errors: errors, errorSchema: errorSchema },
       () => {
         if (this.props.onSubmit) {
           this.props.onSubmit(
@@ -412,5 +438,6 @@ if (process.env.NODE_ENV !== "production") {
     customFormats: PropTypes.object,
     additionalMetaSchemas: PropTypes.arrayOf(PropTypes.object),
     omitExtraData: PropTypes.bool,
+    extraErrors: PropTypes.object,
   };
 }

--- a/test/Form_test.js
+++ b/test/Form_test.js
@@ -2779,4 +2779,56 @@ describe("Form omitExtraData and liveOmit", () => {
 
     expect(comp.state.formData).eql({ foo: "foobar" });
   });
+
+  describe("Async errors", () => {
+    it("should render the async errors", () => {
+      const schema = {
+        type: "object",
+        properties: {
+          foo: { type: "string" },
+          candy: {
+            type: "object",
+            properties: {
+              bar: { type: "string" },
+            },
+          },
+        },
+      };
+
+      const extraErrors = {
+        foo: {
+          __errors: ["some error that got added as a prop"],
+        },
+        candy: {
+          bar: {
+            __errors: ["some other error that got added as a prop"],
+          },
+        },
+      };
+
+      const { node } = createFormComponent({ schema, extraErrors });
+
+      expect(node.querySelectorAll(".error-detail li")).to.have.length.of(2);
+    });
+
+    it("should not block form submission", () => {
+      const onSubmit = sinon.spy();
+      const schema = {
+        type: "object",
+        properties: {
+          foo: { type: "string" },
+        },
+      };
+
+      const extraErrors = {
+        foo: {
+          __errors: ["some error that got added as a prop"],
+        },
+      };
+
+      const { node } = createFormComponent({ schema, extraErrors, onSubmit });
+      Simulate.submit(node);
+      sinon.assert.calledOnce(onSubmit);
+    });
+  });
 });


### PR DESCRIPTION
* implement errorSchema

* add an example to the playground

* improve playground for errorschema

* fix jumpy state changes when typing

* add documentation

* fix typo

* definately fixed documentation this time

* some tests for the async errors

* conform to style

* add an extra test to make sure async errors do not block submission

* change errorSchema prop to extraErrors

### Reasons for making this change

[Please describe them here]

If this is related to existing tickets, include links to them as well.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
